### PR TITLE
mawinter の 重複判定ロジックを削除

### DIFF
--- a/internal/mawinter/service_test.go
+++ b/internal/mawinter/service_test.go
@@ -2,7 +2,6 @@ package mawinter
 
 import (
 	"context"
-	"errors"
 	"mf-importer/internal/logger"
 	"mf-importer/internal/model"
 	"testing"
@@ -51,17 +50,6 @@ func TestMawinter_Regist(t *testing.T) {
 			},
 			args:    args{ctx: context.Background()},
 			wantErr: false,
-		},
-		{
-			name: "error (GET mawinter)",
-			fields: fields{
-				Logger:      logger.NewLogger(),
-				DBClient:    &mockDBClient{},
-				MawClient:   &mockMawinterClient{GetMawinterWebError: errors.New("error")},
-				ProcessDate: time.Now(),
-			},
-			args:    args{ctx: context.Background()},
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -192,110 +180,6 @@ func TestMawinter_getCategoryIDwithExtractCond(t *testing.T) {
 			}
 			if gotOk != tt.wantOk {
 				t.Errorf("Mawinter.getCategoryIDwithExtractCond() gotOk = %v, want %v", gotOk, tt.wantOk)
-			}
-		})
-	}
-}
-
-func Test_judgeAlreadyRegisted(t *testing.T) {
-	type args struct {
-		dr     model.Detail
-		alrecs []model.GetRecord
-	}
-	tests := []struct {
-		name          string
-		args          args
-		wantDuplicate bool
-	}{
-		{
-			name: "false case (Date)",
-			args: args{
-				dr: model.Detail{
-					Date:  time.Date(2010, 1, 26, 0, 0, 0, 0, time.Local),
-					Price: 1234,
-				},
-				alrecs: []model.GetRecord{
-					{
-						ID:           1,
-						CategoryID:   100,
-						CategoryName: "cat1",
-						Datetime:     time.Date(2010, 1, 23, 1, 2, 3, 0, time.Local),
-						From:         fromMawinterWebText,
-						Price:        1234,
-					},
-					{
-						ID:           5,
-						CategoryID:   500,
-						CategoryName: "cat5",
-						Datetime:     time.Date(2010, 1, 24, 1, 2, 3, 0, time.Local),
-						From:         fromMawinterWebText,
-						Price:        5678,
-					},
-				},
-			},
-			wantDuplicate: false,
-		},
-		{
-			name: "false case (Price)",
-			args: args{
-				dr: model.Detail{
-					Date:  time.Date(2010, 1, 23, 1, 2, 3, 0, time.Local),
-					Price: 12345,
-				},
-				alrecs: []model.GetRecord{
-					{
-						ID:           1,
-						CategoryID:   100,
-						CategoryName: "cat1",
-						Datetime:     time.Date(2010, 1, 23, 1, 2, 3, 0, time.Local),
-						From:         fromMawinterWebText,
-						Price:        1234,
-					},
-					{
-						ID:           5,
-						CategoryID:   500,
-						CategoryName: "cat5",
-						Datetime:     time.Date(2010, 1, 24, 1, 2, 3, 0, time.Local),
-						From:         fromMawinterWebText,
-						Price:        5678,
-					},
-				},
-			},
-			wantDuplicate: false,
-		},
-		{
-			name: "true case",
-			args: args{
-				dr: model.Detail{
-					Date:  time.Date(2010, 1, 24, 0, 0, 0, 0, time.Local),
-					Price: 5678,
-				},
-				alrecs: []model.GetRecord{
-					{
-						ID:           1,
-						CategoryID:   100,
-						CategoryName: "cat1",
-						Datetime:     time.Date(2010, 1, 23, 1, 2, 3, 0, time.Local),
-						From:         fromMawinterWebText,
-						Price:        1234,
-					},
-					{
-						ID:           5,
-						CategoryID:   500,
-						CategoryName: "cat5",
-						Datetime:     time.Date(2010, 1, 24, 1, 2, 3, 0, time.Local),
-						From:         fromMawinterWebText,
-						Price:        5678,
-					},
-				},
-			},
-			wantDuplicate: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if gotDuplicate := judgeAlreadyRegisted(tt.args.dr, tt.args.alrecs); gotDuplicate != tt.wantDuplicate {
-				t.Errorf("judgeAlreadyRegisted() = %v, want %v", gotDuplicate, tt.wantDuplicate)
 			}
 		})
 	}

--- a/internal/repository/mawinter.go
+++ b/internal/repository/mawinter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"mf-importer/internal/logger"
 	"mf-importer/internal/model"
 	"net/http"
@@ -60,21 +59,3 @@ func (m *MawinterClient) Regist(ctx context.Context, c model.Detail, catID int) 
 	return nil
 }
 
-func (m *MawinterClient) GetMawinterWeb(ctx context.Context, yyyymm string) (recs []model.GetRecord, err error) {
-	url := m.APIURL + "/" + yyyymm + "?from=mawinter-web"
-	resp, err := http.Get(url)
-	if err != nil {
-		return []model.GetRecord{}, err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return []model.GetRecord{}, err
-	}
-	err = json.Unmarshal(body, &recs)
-	if err != nil {
-		return []model.GetRecord{}, err
-	}
-
-	return recs, nil
-}


### PR DESCRIPTION
重複判定に利用していたエンドポイント `/v2/record/yyyymm` を削除したので一旦このロジックも消す