### PR TITLE
GHCR公開イメージをarm64対応

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: '1.25.6'
 
       - name: Run Lint staticcheck
-        uses: dominikh/staticcheck-action@v1.4.0
+        uses: dominikh/staticcheck-action@v1.4.1
         with:
           version: "latest"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -42,6 +45,7 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -70,6 +74,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -82,6 +89,7 @@ jobs:
         with:
           context: .
           file: ./build/maw/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -110,6 +118,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -122,6 +133,7 @@ jobs:
         with:
           context: .
           file: ./build/api/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -150,6 +162,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -162,6 +177,7 @@ jobs:
         with:
           context: .
           file: ./build/metrics/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -190,6 +206,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -202,6 +221,7 @@ jobs:
         with:
           context: .
           file: ./build/fe/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 概要
- GitHub Actions の publish workflow で 5 つの公開イメージを multi-arch build するように変更
- `linux/amd64` と `linux/arm64` を同じタグ名で push する設定を追加
- 各 job に QEMU セットアップを追加

## 背景
- 現状の公開イメージは `amd64` 前提で、`arm64` 環境では同名イメージをそのまま利用できないため

## 影響範囲
- GHCR に公開している `mf-importer` / `mf-importer-maw` / `mf-importer-api` / `mf-importer-metrics` / `mf-importer-fe`
- ローカルの `make build` や compose 起動フローは変更なし

## 確認
- `git diff --check`
- 実際の multi-arch push 確認はタグ push 時の GitHub Actions 実行で確認予定