### PR TITLE
fix: support Mobile Suica ID suffix in Suica detection

### DIFF
--- a/internal/model/extract.go
+++ b/internal/model/extract.go
@@ -56,10 +56,20 @@ func (e *ExtractRule) AddRule(ers []ExtractRuleDB) (err error) {
 
 // そのレコードが Suica のものかを判定する
 // 内容: '入 XXXX 出 YYYY'
-// 保有金融機関: 'モバイルSuica'
+// 保有金融機関: 'モバイルSuica' or 'モバイルSuica (モバイルSuica ID)'
 func IsSuicaDetail(d Detail) (ok bool) {
-	const mobileSuicaFinIns = "モバイルSuica"
-	if d.FinIns != mobileSuicaFinIns {
+	mobileSuicaFinIns := []string{
+		"モバイルSuica",
+		"モバイルSuica (モバイルSuica ID)",
+	}
+	matched := false
+	for _, s := range mobileSuicaFinIns {
+		if d.FinIns == s {
+			matched = true
+			break
+		}
+	}
+	if !matched {
 		return false
 	}
 	iri_index := strings.Index(d.Name, "入")

--- a/internal/model/extract_test.go
+++ b/internal/model/extract_test.go
@@ -22,6 +22,16 @@ func TestIsSuicaDetail(t *testing.T) {
 			wantOk: true,
 		},
 		{
+			name: "suica with ID suffix",
+			args: args{
+				d: Detail{
+					Name:   "入 SU新深江 出 SU新大阪",
+					FinIns: "モバイルSuica (モバイルSuica ID)",
+				},
+			},
+			wantOk: true,
+		},
+		{
 			name: "no suica(fin_ins)",
 			args: args{
 				d: Detail{


### PR DESCRIPTION
## 概要
モバイルSuicaの `保有金融機関` フィールドが `モバイルSuica (モバイルSuica ID)` の形式の場合でも Suica 交通費として mawinter-api に連携されるよう修正。

## 動機
MoneyForward ME から出力される CSV において、モバイルSuica の取引記録の `保有金融機関` が `モバイルSuica (モバイルSuica ID)` のように ID 付きで出力される場合がある。`IsSuicaDetail()` は `モバイルSuica` との完全一致のみ判定していたため、ID 付きのレコード（例: `入 SU新深江 出 SU新大阪`）が Suica 判定されず、mawinter-api に連携されない問題があった。

## 変更内容
- `internal/model/extract.go`: `IsSuicaDetail()` の `fin_ins` 判定を複数値対応に変更
  - `モバイルSuica` と `モバイルSuica (モバイルSuica ID)` の両方を許可
- `internal/model/extract_test.go`: ID 付きパターンが `true` を返すテストケースを追加

## 影響範囲
- Suica 交通費の mawinter-api 連携（`mf-importer-maw regist`）
- 既存の `モバイルSuica` のみレコードは引き続き正常動作

## テスト結果
`make test` 全テスト合格（gofmt / vet / staticcheck / go test）