### PR TITLE
ci: use GITHUB_TOKEN for GHCR authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       IMAGE_NAME: docker-image
     steps:
@@ -37,8 +40,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_ACCESS_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
         uses: docker/build-push-action@v5
@@ -52,6 +55,9 @@ jobs:
 
   build_and_push_maw:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: checkout
@@ -81,8 +87,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_ACCESS_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
         uses: docker/build-push-action@v5
@@ -96,6 +102,9 @@ jobs:
 
   build_and_push_api:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: checkout
@@ -125,8 +134,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_ACCESS_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
         uses: docker/build-push-action@v5
@@ -140,6 +149,9 @@ jobs:
 
   build_and_push_metrics:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: checkout
@@ -169,8 +181,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_ACCESS_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
         uses: docker/build-push-action@v5
@@ -184,6 +196,9 @@ jobs:
 
   build_and_push_fe:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: checkout
@@ -213,8 +228,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_ACCESS_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## 概要
ghcr.io へのログインに `secrets.GH_ACCESS_TOKEN` (PAT) の代わりに組み込みの `secrets.GITHUB_TOKEN` を使用し、各ジョブに明示的な `permissions` を追加。

## 動機
`docker/login-action@v4` で ghcr.io へのログイン時に `denied: denied` エラーが発生。PAT (`GH_ACCESS_TOKEN`) に `write:packages` スコープが不足していたことが原因。

## 変更内容
- 全5ジョブに `permissions: contents: read, packages: write` を追加
- `username` を `${{ github.repository_owner }}` から `${{ github.actor }}` に変更
- `password` を `${{ secrets.GH_ACCESS_TOKEN }}` から `${{ secrets.GITHUB_TOKEN }}` に変更

## 影響範囲
- `publish.yml` の Docker image publish ジョブ（タグ push 時のみ実行）
- PAT の管理が不要になり、セキュリティと保守性が向上