### PR TITLE
fix: add fullwidth parentheses pattern for Mobile Suica detection

### DIFF
--- a/internal/model/extract.go
+++ b/internal/model/extract.go
@@ -56,11 +56,12 @@ func (e *ExtractRule) AddRule(ers []ExtractRuleDB) (err error) {
 
 // そのレコードが Suica のものかを判定する
 // 内容: '入 XXXX 出 YYYY'
-// 保有金融機関: 'モバイルSuica' or 'モバイルSuica (モバイルSuica ID)'
+// 保有金融機関: 'モバイルSuica' or 'モバイルSuica (モバイルSuica ID)' or 'モバイルSuica（モバイルSuica ID）'
 func IsSuicaDetail(d Detail) (ok bool) {
 	mobileSuicaFinIns := []string{
 		"モバイルSuica",
 		"モバイルSuica (モバイルSuica ID)",
+		"モバイルSuica（モバイルSuica ID）",
 	}
 	matched := false
 	for _, s := range mobileSuicaFinIns {

--- a/internal/model/extract_test.go
+++ b/internal/model/extract_test.go
@@ -32,6 +32,16 @@ func TestIsSuicaDetail(t *testing.T) {
 			wantOk: true,
 		},
 		{
+			name: "suica with ID suffix (fullwidth)",
+			args: args{
+				d: Detail{
+					Name:   "入 千住大橋 出 京成日暮",
+					FinIns: "モバイルSuica（モバイルSuica ID）",
+				},
+			},
+			wantOk: true,
+		},
+		{
 			name: "no suica(fin_ins)",
 			args: args{
 				d: Detail{


### PR DESCRIPTION
## 概要
`IsSuicaDetail()` に全角括弧パターン `モバイルSuica（モバイルSuica ID）` を追加。

## 動機
前回の修正 (#104) で半角括弧 `モバイルSuica (モバイルSuica ID)` を追加したが、実際の MoneyForward ME のデータは全角括弧 `モバイルSuica（モバイルSuica ID）` で出力されていた。このため、Suica 判定に失敗し mawinter-api に連携されない問題が継続していた。

## 変更内容
- `internal/model/extract.go`: 全角括弧パターンを追加
- `internal/model/extract_test.go`: 全角括弧パターンのテストケースを追加（`入 千住大橋 出 京成日暮` + `モバイルSuica（モバイルSuica ID）`）

## テスト結果
`make test` 全テスト合格