### PR TITLE
build(deps): bump simple-git to 3.32.3 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9753,9 +9753,9 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.30.0.tgz",
-      "integrity": "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==",
+      "version": "3.32.3",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.3.tgz",
+      "integrity": "sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@nuxtjs/tailwindcss": "^6.13.1"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "simple-git": "^3.32.3"
   }
 }


### PR DESCRIPTION
Address Dependabot alert #65 (GHSA-r275-fr43-pm7q, CVE-2026-28292,
critical) by adding simple-git to package.json overrides. The
blockUnsafeOperationsPlugin could be bypassed via case-insensitive
protocol.allow config, enabling RCE.

- simple-git: 3.30.0 -> 3.32.3 (transitive, via overrides)
