### PR TITLE
build(deps): bump shell-quote to 1.8.4 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9729,9 +9729,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.3",
-    "simple-git": "^3.32.3"
+    "simple-git": "^3.32.3",
+    "shell-quote": "^1.8.4"
   }
 }


### PR DESCRIPTION
Address Dependabot alert #114 (GHSA-w7jw-789q-3m8p, CVE-2026-9277,
critical) by adding shell-quote to package.json overrides. The quote()
function failed to escape newlines in object .op values, which can
result in command injection when shell-quote output is passed to a
shell.

- shell-quote: 1.8.3 -> 1.8.4 (transitive, via overrides)
