### PR TITLE
ci: pin GitHub Actions to commit SHA and bump to latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tbls.yml
-        uses: actions/checkout@v6
-      - uses: k1low/setup-tbls@v1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: k1LoW/setup-tbls@f25e3d013a596865b2db90dac7ee19e9f15b5780 # v1.4.0
       - name: Wait for ready DB
         run: |
           until mysql -u root -ppassword -h 127.0.0.1 -e '\q'; do sleep 1; done

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22" # 22.x の最新版
           cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build for Docker
         run: docker build -t mf-importer-fe -f build/fe/Dockerfile .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,15 +12,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25.6'
 
       - name: Run Lint staticcheck
-        uses: dominikh/staticcheck-action@v1.4.1
+        uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
           version: "latest"
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,11 @@ jobs:
       IMAGE_NAME: docker-image
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -31,20 +31,20 @@ jobs:
             type=semver,pattern={{major}}
             type=semver,pattern=latest
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./build/Dockerfile
@@ -61,11 +61,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -78,20 +78,20 @@ jobs:
             type=semver,pattern=latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./build/maw/Dockerfile
@@ -108,11 +108,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -125,20 +125,20 @@ jobs:
             type=semver,pattern=latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./build/api/Dockerfile
@@ -155,11 +155,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -172,20 +172,20 @@ jobs:
             type=semver,pattern=latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./build/metrics/Dockerfile
@@ -202,11 +202,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -219,20 +219,20 @@ jobs:
             type=semver,pattern=latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./build/fe/Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
   db-migration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25.6'
 


### PR DESCRIPTION
## 概要
リポジトリ全体で使用している GitHub Actions を **最新版に更新** し、  
サプライチェーン攻撃リスク低減のため **全 Action を commit SHA でピン留め** しました。

## 動機
- 30日以上経過した以下の dependabot PR が古くなり自動 rebase も止まっているため再作成
  - #80: `docker/metadata-action` v4 → v6
  - #82: `docker/build-push-action` v5 → v7
- SHA ピン留めでタグが改ざんされても影響を受けない (GitHub 公式のサプライチェーン対策)
- バージョンコメントを併記することで、dependabot が引き続き更新 PR を作成可能

## 変更内容

### publish.yml (5 ジョブ共通)
| Action | 変更 | 備考 |
|---|---|---|
| `actions/checkout` | v6 → v6.0.3 | SHA ピン留め |
| `docker/metadata-action` | v4 → v6.1.0 | #80 再現 |
| `docker/build-push-action` | v5 → v7.2.0 | #82 再現 |
| `docker/setup-buildx-action` | v4 → v4.1.0 | マイナー上げ |
| `docker/setup-qemu-action` | v4 → v4.1.0 | マイナー上げ |
| `docker/login-action` | v4 → v4.2.0 | マイナー上げ |

### 他のワークフロー
- `docs.yml`: `k1low/setup-tbls@v1` → `k1LoW/setup-tbls@v1.4.0` (キャピタライズ修正)
- `frontend.yml`: `actions/setup-node` v6 → v6.4.0
- `go.yml`: `actions/setup-go` v6 → v6.4.0 / `dominikh/staticcheck-action` SHA ピン留め
- `nix.yml`: `cachix/install-nix-action` v31 → v31.10.6 (CVE 修正含む)
- `test.yml`: `actions/setup-go` v6 → v6.4.0

## 影響範囲
- CI パイプラインのみ。アプリケーションコードには影響なし。
- タグ push 時の `publish.yml` は Docker イメージのメタ計算と push のみ。`DOCKER_BUILD_NO_SUMMARY` 等の削除 env は未使用。

## 動作確認
- `make test` ローカル実行で Go 側の挙動変化がないことを確認 (本 PR では Go 関連バージョンは変更なし)
- CI: Go / IntTest / Frontend / Nix Flake Check が通過すること

## 関連 PR / 後続作業
- マージ後、#80 / #82 を superseded として close します
- dependabot が引き続き SHA コメントを見て更新 PR を作成するため、追加の設定変更は不要です

🤖 Generated with [opencode](https://opencode.ai)